### PR TITLE
Routelist word wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# ide - jetbrains
+/.idea/
+
 # misc
 .DS_Store
 .env.local

--- a/src/components/RouteListDisplay/RouteListDisplay.css
+++ b/src/components/RouteListDisplay/RouteListDisplay.css
@@ -54,9 +54,13 @@
   
   .routeList__pointName {
     flex-basis: 50%;
+    max-width: 50%;
+    text-wrap: initial;
   }
-  
+
   .routeList__pointNotes {
     flex-basis: 40%;
+    max-width: 40%;
+    text-wrap: initial;
   }
   


### PR DESCRIPTION
This improves readabiltiy of the routelist somewhat on smaller configurations/devices.

Before:
![image](https://github.com/Matt-Hurd/speedrun-routing-tool/assets/3527340/5c9d230c-bdcc-4571-9fdb-2ee8a46f4d5d)

After:
![image](https://github.com/Matt-Hurd/speedrun-routing-tool/assets/3527340/c0dde6ce-aa0d-4920-892d-61275f8d4015)

As shown, very long names are not affected by the wrapping. My advice is to individually name these to make more sense for runners in the future.