### PR TITLE
Routelist readability

### DIFF
--- a/src/components/RouteListDisplay/RouteListDisplay.css
+++ b/src/components/RouteListDisplay/RouteListDisplay.css
@@ -8,6 +8,16 @@
     padding: 20px 0; /* Removed padding on sides */
   }
 
+  .routeList__branchName>strong,
+  .routeList__pointId {
+    padding: 0 3px;
+  }
+
+  .routeList__pointName,
+  .routeList__pointNotes {
+    padding: 0 8px
+  }
+
   .routeList__pointId,
 .routeList__pointName {
   border-right: 1px solid #2a0f0f;
@@ -32,7 +42,6 @@
     width: 100%;
     padding: 10px 0;
     border-top: 1px solid #000;
-    white-space: nowrap; /* Added this to stop text from wrapping */
   }
   
   
@@ -49,12 +58,12 @@
   }
   
   .routeList__pointId {
-    flex-basis: 5%;
+    flex-basis: 2.6em;
   }
   
   .routeList__pointName {
-    flex-basis: 50%;
-    max-width: 50%;
+    flex-basis: calc(60% - 2.6em);
+    max-width: calc(60% - 2.6em);
     text-wrap: initial;
   }
 

--- a/src/components/RouteListDisplay/RouteListDisplay.css
+++ b/src/components/RouteListDisplay/RouteListDisplay.css
@@ -45,7 +45,7 @@
   }
 
   .routeList__point--active, .routeList__point.routeList__point--active {
-    background-color: #ad2f2f;
+    background-color: #f58e8e;
   }
   
   .routeList__pointId {

--- a/src/components/RouteListDisplay/RouteListDisplay.css
+++ b/src/components/RouteListDisplay/RouteListDisplay.css
@@ -1,5 +1,5 @@
 .routeList {
-    height: 100vh;
+    height: 100%;
     overflow-y: auto;
     width: 100%;
     display: flex;

--- a/src/components/RouteListDisplay/RouteListDisplay.css
+++ b/src/components/RouteListDisplay/RouteListDisplay.css
@@ -5,7 +5,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    padding: 20px 0; /* Removed padding on sides */
+    padding: 0 0 10px; /* Removed padding on sides */
   }
 
   .routeList__branchName>strong,
@@ -32,7 +32,8 @@
   
   .routeList__branchName {
     font-weight: bold;
-    margin-bottom: 10px;
+    background-color: #a7a7e7;
+    padding: 10px 0;
   }
   
   .routeList__point {


### PR DESCRIPTION
Tweaked the design of the routelist slightly to improve readability;

* Resolved a bug which caused the rout list to be logner than the mosaic window.
* Changed the background color of the active split to be compliant woth the GCAW 2 Standards for accessability.
* Made the start/end of branches more apparent.

Edit:
* Segment number is hardcoded to support up to 3 numbers.

Before:
![image](https://github.com/Matt-Hurd/speedrun-routing-tool/assets/3527340/26c52a25-4773-4387-a6e3-9c1992845e9a)

After:
![image](https://github.com/Matt-Hurd/speedrun-routing-tool/assets/3527340/7620e15d-6d15-4c1f-95eb-722469bdd8f6)
